### PR TITLE
Add Android Jetpack Compose prototype for ROAR welcome screen

### DIFF
--- a/android/RoarApp/.gitignore
+++ b/android/RoarApp/.gitignore
@@ -1,0 +1,14 @@
+# Gradle files
+.gradle/
+build/
+*/build/
+
+# Local configuration
+local.properties
+.idea/
+.DS_Store
+
+# Android Studio
+captures/
+.externalNativeBuild/
+.cxx/

--- a/android/RoarApp/README.md
+++ b/android/RoarApp/README.md
@@ -1,0 +1,19 @@
+# ROAR Android Prototype
+
+This directory contains a Jetpack Compose prototype that mirrors the welcome
+experience built for the SwiftUI iOS app. The screen uses a diagonal gradient,
+welcoming copy, and a primary call-to-action button styled to match the iOS
+prototype.
+
+## Getting started
+
+1. Open the project folder (`android/RoarApp`) in **Android Studio
+   Hedgehog (2023.1.1)** or newer.
+2. Let Android Studio sync the Gradle project. The project is configured for
+   **compile SDK 34** and uses **Kotlin 1.9** with Material 3 Compose.
+3. Run the **`app`** configuration on an Android emulator or physical device
+   running API level 24 or higher.
+
+The main UI is defined in `MainActivity.kt`, specifically within the
+`WelcomeScreen` composable. This mirrors the SwiftUI `WelcomeView` from the iOS
+prototype so design tweaks can be shared across both platforms.

--- a/android/RoarApp/app/build.gradle.kts
+++ b/android/RoarApp/app/build.gradle.kts
@@ -1,0 +1,64 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "com.example.roar"
+    compileSdk = 34
+
+    defaultConfig {
+        applicationId = "com.example.roar"
+        minSdk = 24
+        targetSdk = 34
+        versionCode = 1
+        versionName = "1.0"
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        vectorDrawables {
+            useSupportLibrary = true
+        }
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
+    }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+    buildFeatures {
+        compose = true
+    }
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.3"
+    }
+    packaging {
+        resources {
+            excludes += "/META-INF/{AL2.0,LGPL2.1}"
+        }
+    }
+}
+
+dependencies {
+    implementation("androidx.core:core-ktx:1.12.0")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.6.2")
+    implementation("androidx.activity:activity-compose:1.8.0")
+    implementation(platform("androidx.compose:compose-bom:2023.10.01"))
+    implementation("androidx.compose.ui:ui")
+    implementation("androidx.compose.ui:ui-graphics")
+    implementation("androidx.compose.ui:ui-tooling-preview")
+    implementation("androidx.compose.material3:material3")
+
+    debugImplementation("androidx.compose.ui:ui-tooling")
+    debugImplementation("androidx.compose.ui:ui-test-manifest")
+}

--- a/android/RoarApp/app/proguard-rules.pro
+++ b/android/RoarApp/app/proguard-rules.pro
@@ -1,0 +1,1 @@
+# Add project specific ProGuard rules here.

--- a/android/RoarApp/app/src/main/AndroidManifest.xml
+++ b/android/RoarApp/app/src/main/AndroidManifest.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application
+        android:allowBackup="true"
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.RoarApp">
+        <activity
+            android:name="com.example.roar.MainActivity"
+            android:exported="true"
+            android:theme="@style/Theme.RoarApp">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/android/RoarApp/app/src/main/java/com/example/roar/MainActivity.kt
+++ b/android/RoarApp/app/src/main/java/com/example/roar/MainActivity.kt
@@ -1,0 +1,134 @@
+package com.example.roar
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.example.roar.ui.theme.AccentDeepBlue
+import com.example.roar.ui.theme.BackgroundBottom
+import com.example.roar.ui.theme.BackgroundTop
+import com.example.roar.ui.theme.RoarAppTheme
+
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            RoarAppTheme {
+                Surface(modifier = Modifier.fillMaxSize(), color = Color.Transparent) {
+                    WelcomeScreen()
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun WelcomeScreen(modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .drawBehind {
+                val gradient = Brush.linearGradient(
+                    colors = listOf(BackgroundTop, BackgroundBottom),
+                    start = Offset.Zero,
+                    end = Offset(size.width, size.height)
+                )
+                drawRect(brush = gradient)
+            }
+            .padding(horizontal = 24.dp, vertical = 48.dp)
+    ) {
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Spacer(modifier = Modifier.weight(1f))
+
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text(
+                    text = stringResource(id = R.string.welcome_title),
+                    style = MaterialTheme.typography.headlineLarge,
+                    fontWeight = FontWeight.Bold,
+                    color = Color.White,
+                    textAlign = TextAlign.Center
+                )
+                Text(
+                    text = stringResource(id = R.string.welcome_description),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = Color.White.copy(alpha = 0.9f),
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.padding(horizontal = 8.dp)
+                )
+            }
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            Button(
+                onClick = { /* TODO: Future navigation to onboarding flow */ },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .shadow(
+                        elevation = 12.dp,
+                        shape = RoundedCornerShape(16.dp),
+                        clip = false
+                    ),
+                shape = RoundedCornerShape(16.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = Color.White,
+                    contentColor = AccentDeepBlue
+                ),
+                contentPadding = PaddingValues(vertical = 16.dp),
+                elevation = ButtonDefaults.buttonElevation(
+                    defaultElevation = 0.dp,
+                    pressedElevation = 0.dp
+                )
+            ) {
+                Text(
+                    text = stringResource(id = R.string.welcome_button),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold
+                )
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+        }
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFFDFE6FD)
+@Composable
+fun WelcomeScreenPreview() {
+    RoarAppTheme {
+        WelcomeScreen()
+    }
+}

--- a/android/RoarApp/app/src/main/java/com/example/roar/ui/theme/Color.kt
+++ b/android/RoarApp/app/src/main/java/com/example/roar/ui/theme/Color.kt
@@ -1,0 +1,8 @@
+package com.example.roar.ui.theme
+
+import androidx.compose.ui.graphics.Color
+
+val BackgroundTop = Color(0xFFB3D6FD)
+val BackgroundBottom = Color(0xFFDFE6FD)
+val AccentDeepBlue = Color(0xFF1B5540)
+val TextOnLight = Color.White

--- a/android/RoarApp/app/src/main/java/com/example/roar/ui/theme/Theme.kt
+++ b/android/RoarApp/app/src/main/java/com/example/roar/ui/theme/Theme.kt
@@ -1,0 +1,40 @@
+package com.example.roar.ui.theme
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+
+private val LightColorScheme = lightColorScheme(
+    primary = AccentDeepBlue,
+    onPrimary = Color.White,
+    background = BackgroundBottom,
+    onBackground = Color.White,
+    surface = Color.Transparent,
+    onSurface = Color.White
+)
+
+private val DarkColorScheme = darkColorScheme(
+    primary = AccentDeepBlue,
+    onPrimary = Color.White,
+    background = AccentDeepBlue,
+    onBackground = Color.White,
+    surface = Color(0xFF0F1F1A),
+    onSurface = Color.White
+)
+
+@Composable
+fun RoarAppTheme(
+    useDarkTheme: Boolean = isSystemInDarkTheme(),
+    content: @Composable () -> Unit
+) {
+    val colorScheme = if (useDarkTheme) DarkColorScheme else LightColorScheme
+
+    MaterialTheme(
+        colorScheme = colorScheme,
+        typography = Typography,
+        content = content
+    )
+}

--- a/android/RoarApp/app/src/main/java/com/example/roar/ui/theme/Type.kt
+++ b/android/RoarApp/app/src/main/java/com/example/roar/ui/theme/Type.kt
@@ -1,0 +1,5 @@
+package com.example.roar.ui.theme
+
+import androidx.compose.material3.Typography
+
+val Typography = Typography()

--- a/android/RoarApp/app/src/main/res/drawable/ic_launcher_background.xml
+++ b/android/RoarApp/app/src/main/res/drawable/ic_launcher_background.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path
+        android:fillColor="@color/ic_launcher_background"
+        android:pathData="M0,0h108v108h-108z"/>
+</vector>

--- a/android/RoarApp/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/android/RoarApp/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,14 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <group android:scaleX="0.6" android:scaleY="0.6" android:translateX="21.6" android:translateY="21.6">
+        <path
+            android:fillColor="#FFFFFFFF"
+            android:pathData="M54,0A54,54 0 1,1 0,54A54,54 0 0,1 54,0Z"/>
+        <path
+            android:fillColor="#FF1B5540"
+            android:pathData="M36,24c-6.627,0 -12,5.373 -12,12s5.373,12 12,12 12,-5.373 12,-12 -5.373,-12 -12,-12zm0,6c3.309,0 6,2.691 6,6s-2.691,6 -6,6 -6,-2.691 -6,-6 2.691,-6 6,-6z"/>
+    </group>
+</vector>

--- a/android/RoarApp/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/android/RoarApp/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/android/RoarApp/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/android/RoarApp/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/android/RoarApp/app/src/main/res/values-night/themes.xml
+++ b/android/RoarApp/app/src/main/res/values-night/themes.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.RoarApp" parent="android:Theme.Material.NoActionBar">
+        <item name="android:statusBarColor">@android:color/transparent</item>
+    </style>
+</resources>

--- a/android/RoarApp/app/src/main/res/values/colors.xml
+++ b/android/RoarApp/app/src/main/res/values/colors.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="background_top">#FFB3D6FD</color>
+    <color name="background_bottom">#FFDFE6FD</color>
+    <color name="accent_deep_blue">#FF1B5540</color>
+    <color name="ic_launcher_background">#FF1B5540</color>
+</resources>

--- a/android/RoarApp/app/src/main/res/values/strings.xml
+++ b/android/RoarApp/app/src/main/res/values/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">ROAR</string>
+    <string name="welcome_title">Welcome to ROAR</string>
+    <string name="welcome_description">Track your emotional wellbeing with daily reflections, gentle insights, and affirmations.</string>
+    <string name="welcome_button">Start Your Journey</string>
+</resources>

--- a/android/RoarApp/app/src/main/res/values/themes.xml
+++ b/android/RoarApp/app/src/main/res/values/themes.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.RoarApp" parent="android:Theme.Material.Light.NoActionBar">
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:windowLightStatusBar">true</item>
+    </style>
+</resources>

--- a/android/RoarApp/build.gradle.kts
+++ b/android/RoarApp/build.gradle.kts
@@ -1,0 +1,4 @@
+plugins {
+    id("com.android.application") version "8.1.2" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.10" apply false
+}

--- a/android/RoarApp/gradle.properties
+++ b/android/RoarApp/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+android.useAndroidX=true
+kotlin.code.style=official

--- a/android/RoarApp/settings.gradle.kts
+++ b/android/RoarApp/settings.gradle.kts
@@ -1,0 +1,2 @@
+rootProject.name = "RoarApp"
+include(":app")


### PR DESCRIPTION
## Summary
- add a Jetpack Compose Android app that mirrors the iOS welcome experience
- define Compose theme, resources, and UI to match gradient, typography, and CTA styling
- document how to open and run the Android project in Android Studio

## Testing
- not run (Android build requires Android Studio environment)


------
https://chatgpt.com/codex/tasks/task_b_68e54acadce8832891c0c8ef5648df95